### PR TITLE
v1.0

### DIFF
--- a/src/code.sh
+++ b/src/code.sh
@@ -27,7 +27,7 @@ main () {
   docker load < /home/dnanexus/"${DOCKER_IMAGE_FILE}"
   echo "Using docker image ${DOCKER_IMAGE_NAME}"
   docker run -v /home/dnanexus:/home/dnanexus "${DOCKER_IMAGE_NAME}" view "$vcf_file_path"##idx##"$vcf_index_path" \
-      -R "$bedfile_path" -O z -o ${out_dir}/"$vcf_file_prefix".vcf.gz
+      -R "$bedfile_path" -O z -o ${out_dir}/"$vcf_file_prefix".bedfiltered.vcf.gz
 
   # Create output directory, move output file into directory, and upload outputs
   # dx-upload-all-outputs uploads contents of the subdirectories on the path $HOME/out/


### PR DESCRIPTION
Create app to be added to MokaPIPE workflow - first release.
- Runs bcftools view v1.13
- Uses the '-R' argument to supply a bed file containing regions to restrict the input file on. Returns all positions overlapping the regions specified in the bed file. Therefore indels that cover both inside and outside a region are returned.
- Switch from using executable to using compressed tarball of the dockerised tool stored in 001_ToolsReferenceData - created using the Dockerfile and commands in the readme (also stored in this release)
- Uses Ubuntu 20.04 app execution environment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/dnanexus_filter_vcf_with_bedfile/5)
<!-- Reviewable:end -->
